### PR TITLE
prepare for new configuration from shared operator code

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -16,6 +16,8 @@ package authentication
 import (
 	"time"
 
+	"k8s.io/client-go/rest"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
@@ -24,8 +26,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticatorfactory"
 )
 
-func NewFromConfig(cfg config.Configuration) (authenticator.Request, error) {
-	cl, err := cfg.KubernetesClientset()
+func NewFromConfig(cfg config.Configuration, kubeConfig *rest.Config) (authenticator.Request, error) {
+	cl, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
@@ -53,8 +55,8 @@ const (
 
 // FromConfiguration is a factory function to create instances of the Controller based on the service provider
 // configuration.
-func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceProviderConfiguration) (Controller, error) {
-	authtor, err := authentication.NewFromConfig(fullConfig)
+func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceProviderConfiguration, kubeConfig *rest.Config) (Controller, error) {
+	authtor, err := authentication.NewFromConfig(fullConfig, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +70,7 @@ func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceP
 		return nil, err
 	}
 
-	cl, err := fullConfig.KubernetesClient(client.Options{Scheme: scheme})
+	cl, err := client.New(kubeConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, err
 	}

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,7 +1,11 @@
 # This configuration is shared between the OAuth Service and the SPI operator
 
+sharedSecret: <SHARED_SECRET_VALUE>
 serviceProviders:
-- type: GitHub
-  clientId: "38eadf05310178513aed"
-  clientSecret: "1f73dd86638b9bc09f6e7b364d6f9bbad949cdaa"
-  redirectUrl: https://localhost:8080/github/callback
+  - type: GitHub
+    clientId: "123"
+    clientSecret: "42"
+  - type: Quay
+    clientId: "456"
+    clientSecret: "54"
+baseUrl: http://<OAUTH_HOST_VALUE>

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,12 +1,7 @@
 # This configuration is shared between the OAuth Service and the SPI operator
 
-sharedSecretFile: /tmp/over-there
 serviceProviders:
 - type: GitHub
-  clientId: "123"
-  clientSecret: "42"
+  clientId: "38eadf05310178513aed"
+  clientSecret: "1f73dd86638b9bc09f6e7b364d6f9bbad949cdaa"
   redirectUrl: https://localhost:8080/github/callback
-- type: Quay
-  clientId: "456"
-  clientSecret: "54"
-  redirectUrl: https://localhost:8080/quay/callback

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/redhat-appstudio/service-provider-integration-operator v0.2.0
+	github.com/redhat-appstudio/service-provider-integration-operator v0.2.1-0.20220120153733-c36682a4fd7d
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/service-provider-integration-operator v0.2.0 h1:tMkt8tvY2uli1C+8LPYSsh2rdE12/pSKB6IXS1CEeLo=
-github.com/redhat-appstudio/service-provider-integration-operator v0.2.0/go.mod h1:Ps5dMLwMKz4vGFcyNVDUI36KuWLz+yNGMBjZL2MQLPg=
+github.com/redhat-appstudio/service-provider-integration-operator v0.2.1-0.20220120153733-c36682a4fd7d h1:KcjU3UA/qXAh2zErtFELu9VCp+pgJdupCprkbNrgiKs=
+github.com/redhat-appstudio/service-provider-integration-operator v0.2.1-0.20220120153733-c36682a4fd7d/go.mod h1:Ps5dMLwMKz4vGFcyNVDUI36KuWLz+yNGMBjZL2MQLPg=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		zap.ReplaceGlobals(logger)
 	}
 
-	cfg, err := config.Config(args.ConfigFile)
+	cfg, err := config.LoadFrom(args.ConfigFile)
 	if err != nil {
 		zap.L().Error("failed to initialize the configuration", zap.Error(err))
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/alexflint/go-arg"
 
 	"github.com/redhat-appstudio/service-provider-integration-oauth/controllers"
@@ -33,6 +36,7 @@ type cliArgs struct {
 	ConfigFile string `arg:"-c, --config-file, env" default:"/etc/spi/config.yaml" help:"The location of the configuration file"`
 	Port       int    `arg:"-p, --port, env" default:"8000" help:"The port to listen on"`
 	DevMode    bool   `arg:"-d, --dev-mode, env" default:"false" help:"use dev-mode logging"`
+	KubeConfig string `arg:"-k, --kubeconfig, env" default:"" help:""`
 }
 
 func OkHandler(w http.ResponseWriter, _ *http.Request) {
@@ -52,26 +56,26 @@ func main() {
 		zap.ReplaceGlobals(logger)
 	}
 
-	pcfg, err := config.LoadFrom(args.ConfigFile)
-	if err != nil {
-		zap.L().Error("failed to load configuration", zap.Error(err))
-		os.Exit(1)
-	}
-
-	cfg, err := pcfg.Inflate()
+	cfg, err := config.Config(args.ConfigFile)
 	if err != nil {
 		zap.L().Error("failed to initialize the configuration", zap.Error(err))
 		os.Exit(1)
 	}
 
-	start(cfg, args.Port)
+	kubeConfig, err := kubernetesConfig(args.KubeConfig)
+	if err != nil {
+		zap.L().Error("failed to create kubernetes configuration", zap.Error(err))
+		os.Exit(1)
+	}
+
+	start(cfg, args.Port, kubeConfig)
 }
 
-func start(cfg config.Configuration, port int) {
+func start(cfg config.Configuration, port int, kubeConfig *rest.Config) {
 	router := mux.NewRouter()
 
 	for _, sp := range cfg.ServiceProviders {
-		controller, err := controllers.FromConfiguration(cfg, sp)
+		controller, err := controllers.FromConfiguration(cfg, sp, kubeConfig)
 		if err != nil {
 			zap.L().Error("failed to initialize controller: %s", zap.Error(err))
 		}
@@ -89,5 +93,13 @@ func start(cfg config.Configuration, port int) {
 	err := http.ListenAndServe(fmt.Sprintf(":%d", port), router)
 	if err != nil {
 		zap.L().Error("failed to start the HTTP server", zap.Error(err))
+	}
+}
+
+func kubernetesConfig(kubeConfig string) (*rest.Config, error) {
+	if kubeConfig == "" {
+		return rest.InClusterConfig()
+	} else {
+		return clientcmd.BuildConfigFromFlags("", kubeConfig)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
updates the code to use new configuration from https://github.com/redhat-appstudio/service-provider-integration-operator/pull/53

that is:
 - get oauth base url from env variable instead of config file
 - get shared secret from env variable instead of config file
 - create kubernetes config/client on it's own

I'll undraft this once shared code from operator is merged

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-48


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
It's hard to test before operator code is merged. You can do one of following:
 - checkout operator `svpi48-config` branch and replace the module with local path
 - use `github.com/sparkoo/service-provider-integration-operator v0.0.1-cfg` module instead and overwrite all imports
 - use `quay.io/mvala/spi-oauth:svpi48` image directly
