### PR TITLE
build: Push images on git tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,10 @@ name: Container build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 jobs:
 
@@ -25,10 +28,23 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/redhat-appstudio/service-provider-integration-oauth
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=next,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to docker.io
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -36,17 +52,15 @@ jobs:
           registry: docker.io
       - name: Login to quay.io
         uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
-      - name: Docker Build & Push
-        uses: docker/build-push-action@v1.1.0
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-          registry: quay.io
-          repository: redhat-appstudio/service-provider-integration-oauth
-          dockerfile: ./Dockerfile
-          tags: next
-          tag_with_sha: true
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### What does this PR do?
Port of https://github.com/redhat-appstudio/service-provider-integration-operator/pull/99
Added ability to build images on git tag pushes.

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
n/a


### How to test this PR?
- `git tag xxx && git push origin --tags`
- image build github action should be triggered
