### PR TITLE
Manual username + password upload for Quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 # build service
 # Note that we're not running the tests here. Our integration tests depend on a running cluster which would not be
 # available in the docker build.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o spi-oauth main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOPRIVATE=* go build -a -o spi-oauth main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 # build service
 # Note that we're not running the tests here. Our integration tests depend on a running cluster which would not be
 # available in the docker build.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOPRIVATE=* go build -a -o spi-oauth main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o spi-oauth main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/samples/access_token_data.json
+++ b/samples/access_token_data.json
@@ -1,6 +1,7 @@
 {
-  "access_token": "123",
-  "expiry": "123135429034087083",
+  "username": "mshaposhnik+tekton_demo",
+  "access_token": "TPQ8OQSY8CC7SNLKH7T7RFN9G8B8N2ZDNC09MI7R8TF5DBZFX7T0NGO2PQD6A3AJ",
+  "expiry": 90340870832134324,
   "refresh_token": "",
   "token_type": "bearer"
 }

--- a/samples/access_token_data.json
+++ b/samples/access_token_data.json
@@ -1,7 +1,6 @@
 {
-  "username": "mshaposhnik+tekton_demo",
-  "access_token": "TPQ8OQSY8CC7SNLKH7T7RFN9G8B8N2ZDNC09M......",
-  "expiry": 90340870832134324,
+  "access_token": "123",
+  "expiry": 123135429034087083,
   "refresh_token": "",
   "token_type": "bearer"
 }

--- a/samples/access_token_data.json
+++ b/samples/access_token_data.json
@@ -1,6 +1,6 @@
 {
   "username": "mshaposhnik+tekton_demo",
-  "access_token": "TPQ8OQSY8CC7SNLKH7T7RFN9G8B8N2ZDNC09MI7R8TF5DBZFX7T0NGO2PQD6A3AJ",
+  "access_token": "TPQ8OQSY8CC7SNLKH7T7RFN9G8B8N2ZDNC09M......",
   "expiry": 90340870832134324,
   "refresh_token": "",
   "token_type": "bearer"

--- a/samples/username_password_data.json
+++ b/samples/username_password_data.json
@@ -1,8 +1,5 @@
 {
   "username": "quay+user_demo",
   "access_token": "TPQ8OQSY8CC7SNLKH7",
-  "expiry": 90340870832134324,
-  "refresh_token": "",
-  "token_type": "robot"
 }
 

--- a/samples/username_password_data.json
+++ b/samples/username_password_data.json
@@ -1,5 +1,5 @@
 {
   "username": "quay+user_demo",
-  "access_token": "TPQ8OQSY8CC7SNLKH7",
+  "access_token": "TPQ8OQSY8CC7SNLKH7"
 }
 

--- a/samples/username_password_data.json
+++ b/samples/username_password_data.json
@@ -3,6 +3,6 @@
   "access_token": "TPQ8OQSY8CC7SNLKH7",
   "expiry": 90340870832134324,
   "refresh_token": "",
-  "token_type": "bearer"
+  "token_type": "robot"
 }
 

--- a/samples/username_password_data.json
+++ b/samples/username_password_data.json
@@ -1,0 +1,8 @@
+{
+  "username": "quay+user_demo",
+  "access_token": "TPQ8OQSY8CC7SNLKH7",
+  "expiry": 90340870832134324,
+  "refresh_token": "",
+  "token_type": "bearer"
+}
+


### PR DESCRIPTION
Signed-off-by: Max Shaposhnik <mshaposh@redhat.com>

### What does this PR do?
Allows manual username + password  (typically robot account) upload for Quay

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/projects/SVPI/issues/SVPI-107


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
