### PR TITLE
Improve error messages

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -110,6 +110,10 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)
 	if err != nil {
 		logErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to determine if the authenticated user has access", err)
+		zap.L().Warn("The token is incorrect or the SPI OAuth service is not configured properly " +
+			"and the API_SERVER environment variable points it to the incorrect Kubernetes API server. " +
+			"If SPI is running with Devsandbox Proxy or KCP, make sure this env var points to the Kubernetes API proxy," +
+			" otherwise unset this variable. See more https://github.com/redhat-appstudio/infra-deployments/pull/264")
 		return
 	}
 


### PR DESCRIPTION
### What does this PR do?
Improve error messages when failing to authorize the token with the API server in the OAuth service

### Screenshot/screencast of this PR
user's view
<img width="1638" alt="Знімок екрана 2022-05-03 о 11 15 11" src="https://user-images.githubusercontent.com/1614429/166423033-c167cb52-d45c-4551-bcbb-d975c7efe2e5.png">
admin view from oauth service logs.
<img width="1675" alt="Знімок екрана 2022-05-03 о 11 15 27" src="https://user-images.githubusercontent.com/1614429/166423021-cc793016-d9e1-49c3-87dc-c8f48a4b65c2.png">



### What issues does this PR fix or reference?
We're using the `SelfSubjectAccessReview` request to the Kubernetes API to figure out whether the token supplied to us in the request has enough permissions. If the token is correct, this should never fail. see more  https://issues.redhat.com/browse/SVPI-111

### How to test this PR?
- Deploy Spi OAuth image `quay.io/skabashn/service-provider-integration-oauth:svpi111-improve-error-message_2022_05_03_10_26_47`
- Set `API_URL` environment variable of OAuth service to something dummy url
- make any request to OAuth service that requires authentication.

