### PR TITLE
Enable cors for certain domains

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,4 +93,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check if dockerimage build is working
-        run: docker build -f ./Dockerfile .
+        run: c

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,4 +93,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check if dockerimage build is working
-        run: c
+        run: docker build -f ./Dockerfile .

--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -70,8 +70,7 @@ func (a Authenticator) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if token == "" {
-		zap.L().Warn("Undesired usage of k8s_token as query parameter. Please consider to use Authorization header instead of query parameter.")
-		logDebugAndWriteResponse(w, http.StatusUnauthorized, "failed extract authorization info either from headers or form/query parameters")
+		logDebugAndWriteResponse(w, http.StatusUnauthorized, "failed extract authorization info either from headers or form parameters")
 		return
 	}
 	hasAccess, err := a.tokenReview(token, r)

--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -97,8 +97,8 @@ func (a Authenticator) Login(w http.ResponseWriter, r *http.Request) {
 	zap.L().Debug("/login ok")
 }
 
-func NewAuthenticator(sessionManager *scs.Manager, cl AuthenticatingClient) Authenticator {
-	return Authenticator{
+func NewAuthenticator(sessionManager *scs.Manager, cl AuthenticatingClient) *Authenticator {
+	return &Authenticator{
 		K8sClient:      cl,
 		SessionManager: sessionManager,
 	}

--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -27,6 +27,7 @@ type Authenticator struct {
 }
 
 func (a Authenticator) tokenReview(token string, req *http.Request) (bool, error) {
+	//TODO not working. temporary disabled.
 	//review := v1.TokenReview{
 	//	Spec: v1.TokenReviewSpec{
 	//		Token: token,
@@ -97,7 +98,6 @@ func (a Authenticator) Login(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewAuthenticator(sessionManager *scs.Manager, cl AuthenticatingClient) Authenticator {
-
 	return Authenticator{
 		K8sClient:      cl,
 		SessionManager: sessionManager,

--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/alexedwards/scs"
+	"go.uber.org/zap"
+)
+
+type Authenticator struct {
+	K8sClient      AuthenticatingClient
+	SessionManager *scs.Manager
+}
+
+func (a Authenticator) tokenReview(token string, req *http.Request) (bool, error) {
+	//review := v1.TokenReview{
+	//	Spec: v1.TokenReviewSpec{
+	//		Token: token,
+	//	},
+	//}
+	//
+	//ctx := WithAuthIntoContext(token, req.Context())
+	//
+	//if err := a.K8sClient.Create(ctx, &review); err != nil {
+	//	zap.L().Error("token review error", zap.Error(err))
+	//	return false, err
+	//}
+	//
+	//zap.L().Debug("token review result", zap.Stringer("review", &review))
+	//return review.Status.Authenticated, nil
+	return true, nil
+}
+func (a *Authenticator) GetToken(r *http.Request) (string, error) {
+	zap.L().Debug("/GetToken")
+	session := a.SessionManager.Load(r)
+	token, err := session.GetString("k8s_token")
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", errors.New("no token associated with the given session")
+	}
+	return token, nil
+}
+
+func (a Authenticator) Login(w http.ResponseWriter, r *http.Request) {
+	zap.L().Debug("/login")
+
+	session := a.SessionManager.Load(r)
+
+	token := r.FormValue("k8s_token")
+
+	if token == "" {
+		token = ExtractTokenFromAuthorizationHeader(r.Header.Get("Authorization"))
+	}
+
+	if token == "" {
+		zap.L().Warn("Undesired usage of k8s_token as query parameter. Please consider to use Authorization header instead of query parameter.")
+		logDebugAndWriteResponse(w, http.StatusUnauthorized, "failed extract authorization info either from headers or form/query parameters")
+		return
+	}
+	hasAccess, err := a.tokenReview(token, r)
+	if err != nil {
+		logErrorAndWriteResponse(w, http.StatusUnauthorized, "failed to determine if the authenticated user has access", err)
+		zap.L().Warn("The token is incorrect or the SPI OAuth service is not configured properly " +
+			"and the API_SERVER environment variable points it to the incorrect Kubernetes API server. " +
+			"If SPI is running with Devsandbox Proxy or KCP, make sure this env var points to the Kubernetes API proxy," +
+			" otherwise unset this variable. See more https://github.com/redhat-appstudio/infra-deployments/pull/264")
+		return
+	}
+
+	if !hasAccess {
+		logDebugAndWriteResponse(w, http.StatusUnauthorized, "authenticating the request in Kubernetes unsuccessful")
+		return
+	}
+
+	if err := session.PutString(w, "k8s_token", token); err != nil {
+		logErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to persist session data", err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	zap.L().Debug("/login ok")
+}
+
+func NewAuthenticator(sessionManager *scs.Manager, cl AuthenticatingClient) Authenticator {
+
+	return Authenticator{
+		K8sClient:      cl,
+		SessionManager: sessionManager,
+	}
+}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -91,9 +91,9 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 		logErrorAndWriteResponse(w, http.StatusBadRequest, "failed to decode the OAuth state", err)
 		return
 	}
-	token, error := c.Authenticator.GetToken(r)
+	token, err := c.Authenticator.GetToken(r)
 	if err != nil {
-		logErrorAndWriteResponse(w, http.StatusUnauthorized, "authenticating the request in Kubernetes unsuccessful", error)
+		logErrorAndWriteResponse(w, http.StatusUnauthorized, "authenticating the request in Kubernetes unsuccessful", err)
 	}
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)
 	if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -90,7 +90,7 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 	}
 	token, err := c.Authenticator.GetToken(r)
 	if err != nil {
-		logErrorAndWriteResponse(w, http.StatusUnauthorized, "authenticating the request in Kubernetes unsuccessful", err)
+		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again.", err)
 	}
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)
 	if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -91,6 +91,7 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 	token, err := c.Authenticator.GetToken(r)
 	if err != nil {
 		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again.", err)
+		return
 	}
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)
 	if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -91,9 +91,7 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 		logErrorAndWriteResponse(w, http.StatusBadRequest, "failed to decode the OAuth state", err)
 		return
 	}
-	zap.L().Info("Authenticator")
 	token, error := c.Authenticator.GetToken(r)
-	zap.L().Info("Authenticator")
 	if err != nil {
 		logErrorAndWriteResponse(w, http.StatusUnauthorized, "authenticating the request in Kubernetes unsuccessful", error)
 	}
@@ -112,21 +110,6 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//flowKey := string(uuid.NewUUID())
-	//
-	//flows := map[string]string{}
-	//if err := session.GetObject("flows", &flows); err != nil {
-	//	logErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to decode session data", err)
-	//	return
-	//}
-
-	///	flows[flowKey] = token
-
-	//if err := session.PutObject(w, "flows", flows); err != nil {
-	//	logErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to encode session data", err)
-	//	return
-	//}
-	//
 	keyedState := exchangeState{
 		AnonymousOAuthState: state,
 	}
@@ -146,8 +129,6 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 		logErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to return redirect notice HTML page", err)
 		return
 	}
-	//
-	//http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 	zap.L().Debug("/authenticate ok")
 }
 
@@ -197,17 +178,6 @@ func (c commonController) finishOAuthExchange(ctx context.Context, r *http.Reque
 	if err != nil {
 		return exchangeResult{result: oauthFinishError}, err
 	}
-
-	//session := c.SessionManager.Load(r)
-	//flows := map[string]string{}
-	//if err = session.GetObject("flows", &flows); err != nil {
-	//	return exchangeResult{result: oauthFinishError}, err
-	//}
-	//
-	//authHeader := flows[state.Key]
-	//if authHeader == "" {
-	//	return exchangeResult{result: oauthFinishK8sAuthRequired}, fmt.Errorf("no active oauth flow found for the state key")
-	//}
 
 	k8sToken, err := c.Authenticator.GetToken(r)
 	if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -45,12 +45,9 @@ type commonController struct {
 }
 
 // exchangeState is the state that we're sending out to the SP after checking the anonymous oauth state produced by
-// the operator as the initial OAuth URL. Notice that the state doesn't contain any sensitive information. It only
-// contains the Key which is the key to the HTTP session that actually contains the authorization header to use when
-// finishing the OAuth flow.
+// the operator as the initial OAuth URL. Notice that the state doesn't contain any sensitive information.
 type exchangeState struct {
 	oauthstate.AnonymousOAuthState
-	Key string `json:"key"`
 }
 
 // exchangeResult this the result of the OAuth exchange with all the data necessary to store the token into the storage

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Controller", func() {
 		Fail("Could not find the token of the default service account in the test namespace", 1)
 		return ""
 	}
-
+	authenticator := NewAuthenticator(scs.NewManager(memstore.New(1000000*time.Hour)), IT.Client)
 	prepareController := func(g Gomega) *commonController {
 		tmpl, err := template.ParseFiles("../static/redirect_notice.html")
 		g.Expect(err).NotTo(HaveOccurred())
@@ -101,8 +101,9 @@ var _ = Describe("Controller", func() {
 				TokenURL:  "https://special.sp/toekn",
 				AuthStyle: oauth2.AuthStyleAutoDetect,
 			},
-			BaseUrl:          "https://spi.on.my.machine",
-			SessionManager:   scs.NewManager(memstore.New(1000000 * time.Hour)),
+			BaseUrl: "https://spi.on.my.machine",
+			//			SessionManager:   scs.NewManager(memstore.New(1000000 * time.Hour)),
+			Authenticator:    &authenticator,
 			RedirectTemplate: tmpl,
 		}
 	}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Controller", func() {
 		Expect(redirect.Query().Get("response_type")).To(Equal("code"))
 		Expect(redirect.Query().Get("state")).NotTo(BeEmpty())
 		Expect(redirect.Query().Get("scope")).To(Equal("a b"))
-		//		Expect(res.Result().Cookies()).NotTo(BeEmpty())
+		Expect(res.Result().Cookies()).To(BeEmpty())
 	})
 
 	When("OAuth initiated", func() {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -122,9 +122,7 @@ var _ = Describe("Controller", func() {
 	}
 
 	authenticateFlow := func(g Gomega, cookies []*http.Cookie) (*commonController, *httptest.ResponseRecorder) {
-		//token := grabK8sToken(g)
 
-		// This is the setup for the HTTP call to /github/authenticate
 		req := httptest.NewRequest("GET", fmt.Sprintf("/?state=%s", prepareAnonymousState()), nil)
 		for _, cookie := range cookies {
 			req.Header.Set("Cookie", cookie.String())

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -19,7 +19,6 @@ import (
 	"html/template"
 	"net/http"
 
-	"github.com/alexedwards/scs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
@@ -49,7 +48,7 @@ const (
 
 // FromConfiguration is a factory function to create instances of the Controller based on the service provider
 // configuration.
-func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceProviderConfiguration, sessionManager *scs.Manager, cl AuthenticatingClient, storage tokenstorage.TokenStorage, redirectTemplate *template.Template) (Controller, error) {
+func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceProviderConfiguration, authenticator *Authenticator, cl AuthenticatingClient, storage tokenstorage.TokenStorage, redirectTemplate *template.Template) (Controller, error) {
 	// use the notifying token storage to automatically inform the cluster about changes in the token storage
 	ts := &tokenstorage.NotifyingTokenStorage{
 		Client:       cl,
@@ -74,7 +73,7 @@ func FromConfiguration(fullConfig config.Configuration, spConfig config.ServiceP
 		TokenStorage:     ts,
 		Endpoint:         endpoint,
 		BaseUrl:          fullConfig.BaseUrl,
-		SessionManager:   sessionManager,
+		Authenticator:    authenticator,
 		RedirectTemplate: redirectTemplate,
 	}, nil
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -15,7 +15,10 @@ package controllers
 
 import (
 	"context"
+	"github.com/alexedwards/scs"
+	"github.com/alexedwards/scs/stores/memstore"
 	"testing"
+	"time"
 
 	authz "k8s.io/api/authorization/v1"
 
@@ -49,7 +52,7 @@ var IT = struct {
 	Clientset        *kubernetes.Clientset
 	TokenStorage     tokenstorage.TokenStorage
 	VaultTestCluster *vault.TestCluster
-	Authenticator    *Authenticator
+	SessionManager   *scs.Manager
 }{}
 
 func TestSuite(t *testing.T) {
@@ -113,6 +116,8 @@ var _ = BeforeSuite(func() {
 		Client:       IT.Client,
 		TokenStorage: IT.TokenStorage,
 	}
+
+	IT.SessionManager = scs.NewManager(memstore.New(1000000 * time.Hour))
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -49,6 +49,7 @@ var IT = struct {
 	Clientset        *kubernetes.Clientset
 	TokenStorage     tokenstorage.TokenStorage
 	VaultTestCluster *vault.TestCluster
+	Authenticator    *Authenticator
 }{}
 
 func TestSuite(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alexedwards/scs v1.4.1
 	github.com/alexflint/go-arg v1.4.3
 	github.com/go-jose/go-jose/v3 v3.0.0
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/vault v1.9.4
 	github.com/onsi/ginkgo v1.16.5
@@ -61,6 +62,7 @@ require (
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -533,6 +533,7 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/favadi/protoc-go-inject-tag v1.3.0/go.mod h1:SSkUBgfqw2IJ2p7NPNKWk0Idwxt/qIt2LQgFPUgRGtc=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -780,6 +781,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func start(cfg config.Configuration, addr string, allowedOrigins []string, kubeC
 	for _, sp := range cfg.ServiceProviders {
 		zap.L().Debug("initializing service provider controller", zap.String("type", string(sp.ServiceProviderType)), zap.String("url", sp.ServiceProviderBaseUrl))
 
-		controller, err := controllers.FromConfiguration(cfg, sp, &authenticator, cl, strg, redirectTpl)
+		controller, err := controllers.FromConfiguration(cfg, sp, authenticator, cl, strg, redirectTpl)
 		if err != nil {
 			zap.L().Error("failed to initialize controller: %s", zap.Error(err))
 		}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,14 @@ import (
 	"fmt"
 	"html/template"
 
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
 	"github.com/alexedwards/scs"
 	"github.com/alexedwards/scs/stores/memstore"
 	"github.com/alexflint/go-arg"
@@ -38,14 +46,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
-	"net"
-	"net/http"
-	"net/url"
-	"os"
-	"os/signal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 type cliArgs struct {

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ type cliArgs struct {
 func (args *cliArgs) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("config-file", args.ConfigFile)
 	enc.AddString("addr", args.Addr)
-	enc.AddString("origins", args.AllowedOrigins)
+	enc.AddString("allowed-origins", args.AllowedOrigins)
 	enc.AddBool("dev-mode", args.DevMode)
 	enc.AddString("kubeconfig", args.KubeConfig)
 	enc.AddString("api-server", args.ApiServer)

--- a/main_test.go
+++ b/main_test.go
@@ -15,12 +15,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/alexflint/go-arg"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/alexflint/go-arg"
 )
 
 func TestHealthCheckHandler(t *testing.T) {
@@ -190,6 +191,49 @@ func TestMiddlewareHandlerCorsPart(t *testing.T) {
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 	rr := httptest.NewRecorder()
 	handler := MiddlewareHandler([]string{"console.dev.redhat.com", "prod.foo.redhat.com"}, http.HandlerFunc(OkHandler))
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the status code is what we expect.
+	if allowOrigin := rr.Header().Get("Access-Control-Allow-Origin"); allowOrigin != "prod.foo.redhat.com" {
+		t.Errorf("handler returned wrong header \"Access-Control-Allow-Origin\": got %v want %v",
+			allowOrigin, "prod.foo.redhat.com")
+	}
+
+}
+
+func TestMiddlewareHandlerCorsPart2(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("OPTIONS", "/github/authenticate?state=eyJhbGciO", nil)
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", "c")
+	req.Header.Set("Access-Control-Request-Headers", "authorization")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Origin", "https://file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com")
+	req.Header.Set("Pragma", "no-cache")
+	req.Header.Set("Referer", "https://file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com/")
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	req.Header.Set("Sec-Fetch-Mode", "cors")
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := MiddlewareHandler([]string{"https://file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com"}, http.HandlerFunc(OkHandler))
 
 	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
 	// directly and pass in our Request and ResponseRecorder.

--- a/main_test.go
+++ b/main_test.go
@@ -246,9 +246,9 @@ func TestMiddlewareHandlerCorsPart2(t *testing.T) {
 	}
 
 	// Check the status code is what we expect.
-	if allowOrigin := rr.Header().Get("Access-Control-Allow-Origin"); allowOrigin != "prod.foo.redhat.com" {
+	if allowOrigin := rr.Header().Get("Access-Control-Allow-Origin"); allowOrigin != "https://file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com" {
 		t.Errorf("handler returned wrong header \"Access-Control-Allow-Origin\": got %v want %v",
-			allowOrigin, "prod.foo.redhat.com")
+			allowOrigin, "https://file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com")
 	}
 
 }

--- a/main_test.go
+++ b/main_test.go
@@ -121,8 +121,11 @@ func TestK8sConfigParse(t *testing.T) {
 	env := []string{"API_SERVER=http://localhost:9001", "API_SERVER_CA_PATH=/etc/ca.crt"}
 	//then
 	args := cliArgs{}
-	parseWithEnv(cmd, env, &args)
+	_, err := parseWithEnv(cmd, env, &args)
 	//when
+	if err != nil {
+		t.Fatal(err)
+	}
 	if args.ApiServer != "http://localhost:9001" {
 		t.Fatal("Unable to parse k8s api server url")
 	}
@@ -137,8 +140,11 @@ func TestCorsConfigParse(t *testing.T) {
 	env := []string{"ALLOWEDORIGINS=prod.acme.com"}
 	//then
 	args := cliArgs{}
-	parseWithEnv(cmd, env, &args)
+	_, err := parseWithEnv(cmd, env, &args)
 	//when
+	if err != nil {
+		t.Fatal(err)
+	}
 	if args.AllowedOrigins != "prod.acme.com" {
 		t.Fatal("Unable to parse CORS allowed origins")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -14,8 +14,12 @@
 package main
 
 import (
+	"fmt"
+	"github.com/alexflint/go-arg"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -109,4 +113,92 @@ func TestCallbackErrorHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
+}
+
+func TestK8sConfigParse(t *testing.T) {
+	//given
+	cmd := ""
+	env := []string{"API_SERVER=http://localhost:9001", "API_SERVER_CA_PATH=/etc/ca.crt"}
+	//then
+	args := cliArgs{}
+	parseWithEnv(cmd, env, &args)
+	//when
+	if args.ApiServer != "http://localhost:9001" {
+		t.Fatal("Unable to parse k8s api server url")
+	}
+	if args.ApiServerCAPath != "/etc/ca.crt" {
+		t.Fatal("Unable to parse k8s ca path")
+	}
+}
+
+func TestCorsConfigParse(t *testing.T) {
+	//given
+	cmd := ""
+	env := []string{"ALLOWEDORIGINS=prod.acme.com"}
+	//then
+	args := cliArgs{}
+	parseWithEnv(cmd, env, &args)
+	//when
+	if args.AllowedOrigins != "prod.acme.com" {
+		t.Fatal("Unable to parse CORS allowed origins")
+	}
+}
+
+func parseWithEnv(cmdline string, env []string, dest interface{}) (*arg.Parser, error) {
+	p, err := arg.NewParser(arg.Config{}, dest)
+	if err != nil {
+		return nil, err
+	}
+
+	// split the command line
+	var parts []string
+	if len(cmdline) > 0 {
+		parts = strings.Split(cmdline, " ")
+	}
+
+	// split the environment vars
+	for _, s := range env {
+		pos := strings.Index(s, "=")
+		if pos == -1 {
+			return nil, fmt.Errorf("missing equals sign in %q", s)
+		}
+		err := os.Setenv(s[:pos], s[pos+1:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// execute the parser
+	return p, p.Parse(parts)
+}
+
+func TestMiddlewareHandlerCorsPart(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("GET", "/github/callback?error=foo&error_description=bar", nil)
+	req.Header.Set("Origin", "prod.foo.redhat.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := MiddlewareHandler([]string{"console.dev.redhat.com", "prod.foo.redhat.com"}, http.HandlerFunc(OkHandler))
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the status code is what we expect.
+	if allowOrigin := rr.Header().Get("Access-Control-Allow-Origin"); allowOrigin != "prod.foo.redhat.com" {
+		t.Errorf("handler returned wrong header \"Access-Control-Allow-Origin\": got %v want %v",
+			allowOrigin, "prod.foo.redhat.com")
+	}
+
 }


### PR DESCRIPTION
### What does this PR do?
1. Enabled cors for certain domains, configured with `ALLOWEDORIGINS` environment variable
2. Add logging midlware. Information about HTTP requests is printed to logs.
3. Added `--addr` parameter to configured HTTP server listening address.
4. Configuration printed to the log during startup
5. HTTP server started in an advanced way. Not it also listens to a signal to stop.
6. Created a separate endpoint for login `"/login"` it associates k8s token with HTTP session.

###An important part of the implementation.
1. At this point, I was not able to successfully do a `TokenReview` on a login step. That means that any string is accepted as k8s token. That is not good but not critical since on the next step `/{sp}/Authenticate`  we are doing 
`SelfSubjectAccessReview` will ensure that the token is valid. I'm going to live some comments in code to not forget to fix this behavior in the next pr. Also, it makes sense to create a dedicated issue for that.
2I've introduced a separate endpoint  `POST /login` that is expecting k8s token. The goal of this endpoint is to associate k8s token with the server-side session. `/{sp}/authenticate` expect that method `POST /login` is already executed at least once. It is not necessary to add an Authorization header. However,  it is important to bring all cookies that were set in `POST /login`  method. 

### Screenshot/screencast of this PR
![Знімок екрана 2022-05-13 о 15 24 12](https://user-images.githubusercontent.com/1614429/168282793-6f8ae7c7-7eac-4827-be14-c7ba3b307ded.png)
![Знімок екрана 2022-05-13 о 15 23 58](https://user-images.githubusercontent.com/1614429/168282799-17ae26b3-bd9e-4964-accd-50cad22bcd08.png)
<img width="1663" alt="Знімок екрана 2022-05-16 о 15 44 40" src="https://user-images.githubusercontent.com/1614429/168595344-0ff88bfb-456f-4a46-936f-ef5eadac6383.png">
<img width="696" alt="Знімок екрана 2022-05-16 о 16 05 47" src="https://user-images.githubusercontent.com/1614429/168599183-71f55685-540d-4fed-80f5-81645a386636.png">
<img width="1368" alt="Знімок екрана 2022-05-16 о 16 05 59" src="https://user-images.githubusercontent.com/1614429/168599198-c8dd457c-727d-44a8-80cd-eacfebca3bba.png">


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-121


### How to test this PR?
1. Deploy `https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/blob/main/server/hack/12_oc_deploy.sh`
2. Configure OAuth
3. Deploy scm UI image `quay.io/skabashn/service-provider-integration-scm-file-retriever-server:svpi121-cors_2022_05_16_15_43_58`
4. set correct allowed origin `kubectl set env deployment/spi-oauth-service ALLOWEDORIGINS=file-retriever-server-service-spi-system.apps.cluster-flmv6.flmv6.sandbox1324.opentlc.com -n spi-system`
5. . Deploy OAuth service image `quay.io/skabashn/service-provider-integration-oauth:svpi121-cors_2022_05_16_15_39_14` 
