### PR TITLE
Add session cookie configuration SameSite=None and Secure=true

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-
 	"strings"
 
 	v1 "k8s.io/api/authorization/v1"

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Controller", func() {
 
 	grabK8sToken := func(g Gomega) string {
 		var secrets *corev1.SecretList
+
 		g.Eventually(func(gg Gomega) {
 			var err error
 			secrets, err = IT.Clientset.CoreV1().Secrets(IT.Namespace).List(context.TODO(), metav1.ListOptions{})
@@ -107,10 +108,12 @@ var _ = Describe("Controller", func() {
 
 	loginFlow := func(g Gomega) (*Authenticator, *httptest.ResponseRecorder) {
 		token := grabK8sToken(g)
+
 		// This is the setup for the HTTP call to /github/authenticate
 		req := httptest.NewRequest("POST", "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		res := httptest.NewRecorder()
+
 		c := prepareAuthenticator(g)
 
 		IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-appstudio/service-provider-integration-oauth
 go 1.17
 
 require (
-	github.com/alexedwards/scs v1.4.1
+	github.com/alexedwards/scs/v2 v2.5.0
 	github.com/alexflint/go-arg v1.4.3
 	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alexedwards/scs v1.4.1 h1:/5L5a07IlqApODcEfZyMsu8Smd1S7Q4nBjEyKxIRTp0=
-github.com/alexedwards/scs v1.4.1/go.mod h1:JRIFiXthhMSivuGbxpzUa0/hT5rz2hpyw61Bmd+S1bg=
+github.com/alexedwards/scs/v2 v2.5.0 h1:zgxOfNFmiJyXG7UPIuw1g2b9LWBeRLh3PjfB9BDmfL4=
+github.com/alexedwards/scs/v2 v2.5.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/alexflint/go-arg v1.4.3 h1:9rwwEBpMXfKQKceuZfYcwuc/7YY7tWJbFsgG5cAU/uo=
 github.com/alexflint/go-arg v1.4.3/go.mod h1:3PZ/wp/8HuqRZMUUgu7I+e1qcpUbvmS258mRXkFH4IA=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=

--- a/main.go
+++ b/main.go
@@ -18,9 +18,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"html/template"
-
-	"github.com/alexedwards/scs/v2/memstore"
-
 	"net"
 	"net/http"
 	"net/url"
@@ -30,10 +27,10 @@ import (
 	"time"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/alexedwards/scs/v2/memstore"
 	"github.com/alexflint/go-arg"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/redhat-appstudio/service-provider-integration-oauth/controllers"
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
@@ -48,6 +45,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-appstudio/service-provider-integration-oauth/controllers"
 )
 
 type cliArgs struct {


### PR DESCRIPTION
### What does this PR do?
Add session cookie configuration SameSite=None and Secure=true to be able to make a login from HAC UI `https://prod.foo.redhat.com:1337/beta/hac/app-studio/import`

### Screenshot/screencast of this PR
Before
<img width="993" alt="Знімок екрана 2022-05-24 о 12 25 20" src="https://user-images.githubusercontent.com/1614429/170000398-44719218-9c36-4994-97f1-6dcba208bffb.png">

After
<img width="1230" alt="Знімок екрана 2022-05-24 о 12 24 54" src="https://user-images.githubusercontent.com/1614429/170000439-6db0cc95-0654-46df-8a34-b3db6fb0e95b.png">

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-113


### How to test this PR?
- Deploy SPI operator and OAuth
- Update OAuth image `quay.io/skabashn/service-provider-integration-oauth:main_2022_05_24_12_20_45`
- Complete OAuth flow.
- Ensure that after the login request `appstudio_spi_session` cookie is set with ```SameSite=None``` and ```Secure=true ``` attributes

Alternative steps 
- Clone https://github.com/openshift/hac-dev/pull/86 
- change 
```
diff --git a/src/utils/create-utils.ts b/src/utils/create-utils.ts
index 4d5d28d..1ef9b9c 100644
--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -264,11 +264,11 @@ export const spiTokenLogin = async (token: string) => {
   const request = {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer sha256~`, <- your openshift token
     },
   };
   return await fetch(
-    'https://spi-oauth-route-spi-system.apps.appstudio-stage.x99m.p1.openshiftapps.com/login',
+    'https://spi-oauth-route-spi-system.apps.cluster-k7qqg.k7qqg.sandbox1857.opentlc.com/login',
     request,
   );
 };
```
- Try to import project.
- Ensure that after the login request `appstudio_spi_session` cookie is set.
 