### PR TITLE
Alternative way to provide a k8s token as query parameter

### DIFF
--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -47,9 +47,17 @@ func (a Authenticator) tokenReview(token string, req *http.Request) (bool, error
 }
 func (a *Authenticator) GetToken(r *http.Request) (string, error) {
 	zap.L().Debug("/GetToken")
-	token := a.SessionManager.GetString(r.Context(), "k8s_token")
+
+	token := r.URL.Query().Get("k8s_token")
 	if token == "" {
-		return "", errors.New("no token associated with the given session")
+		token = a.SessionManager.GetString(r.Context(), "k8s_token")
+	} else {
+		zap.L().Debug("persisting token that was provided by `k8_token` query parameter to the session")
+		a.SessionManager.Put(r.Context(), "k8s_token", token)
+	}
+
+	if token == "" {
+		return "", errors.New("no token associated with the given session or provided as a `k8_token` query parameter")
 	}
 	return token, nil
 }

--- a/controllers/authenticator.go
+++ b/controllers/authenticator.go
@@ -57,7 +57,7 @@ func (a *Authenticator) GetToken(r *http.Request) (string, error) {
 	}
 
 	if token == "" {
-		return "", errors.New("no token associated with the given session or provided as a `k8_token` query parameter")
+		return "", errors.New("no token associated with the given session or provided as a `k8s_token` query parameter")
 	}
 	return token, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -89,7 +89,7 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 	}
 	token, err := c.Authenticator.GetToken(r)
 	if err != nil {
-		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again.", err)
+		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again. Or provide the token as a `k8_token` query parameter.", err)
 		return
 	}
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -89,7 +89,7 @@ func (c commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
 	}
 	token, err := c.Authenticator.GetToken(r)
 	if err != nil {
-		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again. Or provide the token as a `k8_token` query parameter.", err)
+		logErrorAndWriteResponse(w, http.StatusUnauthorized, "No active session was found. Please use `/login` method to authorize your request and try again. Or provide the token as a `k8s_token` query parameter.", err)
 		return
 	}
 	hasAccess, err := c.checkIdentityHasAccess(token, r, state)


### PR DESCRIPTION
### What does this PR do?
Allow to use `k8s_token` for the method `\{sp_provider}\authenticate`

### Screenshot/screencast of this PR
<img width="1675" alt="Знімок екрана 2022-05-30 о 09 31 14" src="https://user-images.githubusercontent.com/1614429/170930850-15aea39d-6b1e-4804-8235-7faa3c774d49.png">
<img width="1344" alt="Знімок екрана 2022-05-30 о 09 32 10" src="https://user-images.githubusercontent.com/1614429/170930863-9cbe1733-e192-45f2-b824-5a0d06a4f359.png">


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-113
Provider a way for cookie-based authentication for the scenarios when other forms are not available.

### How to test this PR?
- Deploy oauth service image `quay.io/skabashn/service-provider-integration-oauth:k8s_token_query_param_2022_05_30_09_25_15`
- Create SPIAccessTokenBinding
- Open Oauth url `oauthURl&k8s_token=token`
- Oauth flow should work out of the box.
- 'appstudio_spi_session` cookie should be set  
