### PR TITLE
Prevent NPE and service failure when there is an error initializing controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func start(cfg config.Configuration, addr string, allowedOrigins []string, kubeC
 
 		controller, err := controllers.FromConfiguration(cfg, sp, authenticator, cl, strg, redirectTpl)
 		if err != nil {
-			zap.L().Error("failed to initialize controller: %s", zap.Error(err))
+			zap.L().Warn("failed to initialize controller for provider %s; It is either not implemented or does not supports OAuth. Error: %s", zap.Error(err))
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func start(cfg config.Configuration, addr string, allowedOrigins []string, kubeC
 
 		controller, err := controllers.FromConfiguration(cfg, sp, authenticator, cl, strg, redirectTpl)
 		if err != nil {
-			zap.L().Warn("failed to initialize controller for provider %s; It is either not implemented or does not supports OAuth. Error: %s", zap.Error(err))
+			zap.L().Warn("failed to initialize controller for provider %s; It is either not implemented or does not supports OAuth. Error: %s", zap.String("type", string(sp.ServiceProviderType)), zap.Error(err))
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func start(cfg config.Configuration, addr string, allowedOrigins []string, kubeC
 
 		controller, err := controllers.FromConfiguration(cfg, sp, authenticator, cl, strg, redirectTpl)
 		if err != nil {
-			zap.L().Warn("failed to initialize controller for provider %s; It is either not implemented or does not supports OAuth. Error: %s", zap.String("type", string(sp.ServiceProviderType)), zap.Error(err))
+			zap.L().Warn("failed to initialize controller for provider; It is either not implemented or does not supports OAuth", zap.String("type", string(sp.ServiceProviderType)), zap.Error(err))
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -239,6 +239,7 @@ func start(cfg config.Configuration, addr string, allowedOrigins []string, kubeC
 		controller, err := controllers.FromConfiguration(cfg, sp, authenticator, cl, strg, redirectTpl)
 		if err != nil {
 			zap.L().Error("failed to initialize controller: %s", zap.Error(err))
+			continue
 		}
 
 		prefix := strings.ToLower(string(sp.ServiceProviderType))


### PR DESCRIPTION
Signed-off-by: Max Shaposhnik <mshaposh@redhat.com>

### What does this PR do?
Prevent NPE and service failure when there is an error initializing controller.
This is also useful for providers which do not support OAuth flow,  they will be just skipped.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
