### PR TITLE
Ensure that it possible to run make test from M1 platform against OpenShift cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help: ## Display this help.
 ##@ Development
 
 test: fmt fmt_license vet envtest ## Run the unit tests
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 run: ## Run the binary
 	go run main.go

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Controller", func() {
 		}).Should(Succeed())
 
 		for _, s := range secrets.Items {
-			if s.Annotations["kubernetes.io/service-account.name"] == "default" {
+			if s.Annotations["kubernetes.io/service-account.name"] == "default" && string(s.Data["token"]) != "" {
 				return string(s.Data["token"])
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
 - Uses ENVTEST tools  with  amd64 architecture. M1 version is not yet available. Context https://github.com/redhat-appstudio/service-provider-integration-operator/pull/149
 - On OpenShift cluster we can have multiple secrets with `[kubernetes.io/service-account.name"] == "default"` some of them may not have `token` data.

### Screenshot/screencast of this PR
<img width="1676" alt="Знімок екрана 2022-06-15 о 17 22 35" src="https://user-images.githubusercontent.com/1614429/173851127-d86a635f-2b7c-43d9-893e-3865da59d6a4.png">


### What issues does this PR fix or reference?
- Not able to run `make test` on M1 platform agains OpenShift cluster


### How to test this PR?
-  run `make test` on M1 platform agains OpenShift cluster

