### PR TITLE
cache deps before building and copying source so that we don't need to re-download them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /spi-oauth
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
 COPY static/callback_success.html static/callback_success.html
 COPY static/callback_error.html static/callback_error.html
 COPY static/redirect_notice.html static/redirect_notice.html


### PR DESCRIPTION
### What does this PR do?
cache deps before building and copying source so that we don't need to re-download them

### Screenshot/screencast of this PR
before
<img width="1721" alt="Знімок екрана 2022-06-23 о 09 28 40" src="https://user-images.githubusercontent.com/1614429/175230672-ee72e224-549f-462b-b9a1-eb409a0eeca4.png">

after
<img width="1728" alt="Знімок екрана 2022-06-23 о 09 29 17" src="https://user-images.githubusercontent.com/1614429/175230691-5ed17b4f-5ad4-4e06-ae80-c5d3eecbcdae.png">

Synced with operator https://github.com/redhat-appstudio/service-provider-integration-operator/blob/16c370c4831e28c3c2dc97b52587d0706fd5aaf8/Dockerfile#L8-L10

### What issues does this PR fix or reference?
When building new docker image go dependencies downloaded each time.


### How to test this PR?
1. `make docker-build` should download dependencies only when they are changed.
