### PR TITLE
Restore original 204 NoContent response code on token upload method

### DIFF
--- a/controllers/handlers.go
+++ b/controllers/handlers.go
@@ -103,7 +103,7 @@ func HandleUpload(uploader TokenUploader) func(http.ResponseWriter, *http.Reques
 			LogErrorAndWriteResponse(w, http.StatusInternalServerError, "failed to upload the token", err)
 			return
 		}
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/controllers/handlers_test.go
+++ b/controllers/handlers_test.go
@@ -145,9 +145,9 @@ func TestUploaderOk(t *testing.T) {
 	router.ServeHTTP(rr, req)
 
 	// Check the status code is what we expect.
-	if status := rr.Code; status != http.StatusAccepted {
+	if status := rr.Code; status != http.StatusNoContent {
 		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusAccepted)
+			status, http.StatusNoContent)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Restore original 204 NoContent response code on token upload method that was changed in https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/103.
Reasons.
- We are do not return any data
- Object is not really ready yet. Some metadata might be updated soon.
- Other code might rely on this status

### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
https://github.com/redhat-appstudio/infra-deployments/pull/475 test is failing
### How to test this PR?
 - make test