### PR TITLE
Redesign of service configuration

### DIFF
--- a/controllers/handlers.go
+++ b/controllers/handlers.go
@@ -112,7 +112,7 @@ func HandleUpload(uploader TokenUploader) func(http.ResponseWriter, *http.Reques
 // - Request logging
 // - CORS processing
 func MiddlewareHandler(allowedOrigins []string, h http.Handler) http.Handler {
-	return handlers.LoggingHandler(&zapio.Writer{Log: zap.L(), Level: zap.InfoLevel},
+	return handlers.LoggingHandler(&zapio.Writer{Log: zap.L(), Level: zap.DebugLevel},
 		handlers.CORS(handlers.AllowedOrigins(allowedOrigins),
 			handlers.AllowCredentials(),
 			handlers.AllowedHeaders([]string{"Accept", "Accept-Language", "Content-Language", "Origin", "Authorization"}))(h))


### PR DESCRIPTION
### What does this PR do?
 - Used a similar set of  configuration parameters for logger configuration
 - Used a similar set of  configuration parameters for vault tls configuration
 - Moved to Debug level output from each request.


```
Options:
  --config-file CONFIG-FILE, -c CONFIG-FILE
                         The location of the configuration file [default: /etc/spi/config.yaml, env: CONFIGFILE]
  --service-addr SERVICE-ADDR, -b SERVICE-ADDR
                         Service address to listen on [default: 0.0.0.0:8000, env: SERVICEADDR]
  --allowed-origins ALLOWED-ORIGINS, -o ALLOWED-ORIGINS
                         Comma-separated list of domains allowed for cross-domain requests [default: https://console.dev.redhat.com,https://prod.foo.redhat.com:1337, env: ALLOWEDORIGINS]
  --kubeconfig KUBECONFIG, -k KUBECONFIG [env: KUBECONFIG]
  --kube-insecure-tls, -f
                         Whether is allowed or not insecure kubernetes tls connection. [default: false, env: KUBEINSECURETLS]
  --api-server API-SERVER, -a API-SERVER
                         host:port of the Kubernetes API server to use when handling HTTP requests [env: API_SERVER]
  --ca-path CA-PATH, -t CA-PATH
                         the path to the CA certificate to use when connecting to the Kubernetes API server [env: API_SERVER_CA_PATH]
  --vault-insecure-tls, -i
                         Whether is allowed or not insecure vault tls connection. [default: false, env: VAULTINSECURETLS]
  --zap-devel, -d        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn) Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) [default: false, env: ZAPDEVEL]
  --zap-encoder ZAP-ENCODER, -e ZAP-ENCODER
                         Zap log encoding (‘json’ or ‘console’) [env: ZAPENCODER]
  --zap-log-level ZAP-LOG-LEVEL, -v ZAP-LOG-LEVEL
                         Zap Level to configure the verbosity of logging [env: ZAPLOGLEVEL]
  --zap-stacktrace-level ZAP-STACKTRACE-LEVEL, -s ZAP-STACKTRACE-LEVEL
                         Zap Level at and above which stacktraces are captured [env: ZAPSTACKTRACELEVEL]
  --zap-time-encoding ZAP-TIME-ENCODING, -t ZAP-TIME-ENCODING
                         one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano' [default: rfc3339, env: ZAPTIMEENCODING]
  --help, -h             display this help and exit

```
### Screenshot/screencast of this PR

<img width="1726" alt="Знімок екрана 2022-07-14 о 13 13 36" src="https://user-images.githubusercontent.com/1614429/178959608-3c711b93-8b92-4190-96bc-d56c5b8c62a1.png">


### What issues does this PR fix or reference?
- make logger output less verbose
- make configuration simular to the spi operator


### How to test this PR?
 - deploy `quay.io/skabashn/service-provider-integration-oauth:main_2022_07_14__13_00_26`
 - create binding
 - upload token or follow OAuth flow.
