### PR TITLE
feat: return HTTP 404 when tokenupload fails due to absent SPIAccessToken

### DIFF
--- a/controllers/handlers.go
+++ b/controllers/handlers.go
@@ -14,11 +14,11 @@
 package controllers
 
 import (
-	"errors"
 	"fmt"
 	"html/template"
-	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
+
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -110,7 +110,7 @@ func HandleUpload(uploader TokenUploader) func(http.ResponseWriter, *http.Reques
 		}
 
 		if err := uploader.Upload(ctx, tokenObjectName, tokenObjectNamespace, data); err != nil {
-			if unwrap := errors.Unwrap(err); kubeErrors.IsNotFound(unwrap) {
+			if kubeErrors.IsNotFound(err) { // supports wrapped errors
 				LogErrorAndWriteResponse(r.Context(), w, http.StatusNotFound, "specified SPIAccessToken does not exist", err)
 				return
 			}

--- a/controllers/handlers_test.go
+++ b/controllers/handlers_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gorilla/mux"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"

--- a/controllers/handlers_test.go
+++ b/controllers/handlers_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -186,6 +188,40 @@ func TestUploader_FailWithEmptyToken(t *testing.T) {
 	if string(data) != "access token can't be omitted or empty" {
 		t.Errorf("expected 'access token can't be omitted or empty' got '%v'", string(data))
 	}
+}
+
+func TestUploader_FailWithAbsentSpiAccessToken(t *testing.T) {
+	uploader := UploadFunc(func(ctx context.Context, tokenObjectName string, tokenObjectNamespace string, data *api.Token) error {
+		assert.Equal(t, "john", tokenObjectName)
+		assert.Equal(t, "namespace", tokenObjectNamespace)
+
+		return fmt.Errorf("mocking a missing SPIAccessToken: %w", errors.NewNotFound(schema.GroupResource{
+			Group:    "testGroup",
+			Resource: "testSPIAccessToken",
+		}, tokenObjectName))
+	})
+
+	req, err := http.NewRequest("POST", "/token/namespace/john", bytes.NewBuffer([]byte(`{"access_token": "2022"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer macky")
+
+	w := httptest.NewRecorder()
+	var router = mux.NewRouter()
+	router.NewRoute().Path("/token/{namespace}/{name}").HandlerFunc(HandleUpload(uploader)).Methods("POST")
+
+	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, string(data), "mocking a missing SPIAccessToken")
 }
 
 func TestUploader_FailWithoutAuthorization(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
When manual token upload fails because the specified token does not exist, the endpoint return 404 NotFound instead of 500.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
![image](https://user-images.githubusercontent.com/73115616/192221855-e3bf8df5-e11a-4d74-8ffb-bb3f61a2c0fc.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
Fixes: https://issues.redhat.com/browse/SVPI-213

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
1. Deploy SPI with SPI service image being: quay.io/pbaran/spis:SVPI-213
2. Create binding as default SA: 
```shell 
# from operator repository
kubectl apply -f hack/give-default-sa-perms-for-accesstokens.yaml
kubectl apply -f samples/binding-read-repo.yaml --as system:serviceaccount:default:default
```
3. Get upload URL and copy it:
```shell
kubectl get spiaccesstokenbinding binding-read-repository -o "jsonpath={.status['uploadUrl']}"
```
4. Get default SA token:
```shell
SA_TOKEN=`hack/get-default-sa-token.sh`
```
5. Try manual upload:
```shell
 #change the last character of the copied upload URL so that the token with this name does not exist
curl --include \
--insecure \
--header "Authorization: Bearer $SA_TOKEN" \
--data "{\"access_token\": \"random\"}" \
https://spi.192.168.59.130.nip.io/token/default/generated-spi-access-token-x6r55 #replace with your URL
```
6. You should see something like this: 
```
HTTP/2 404 
date: Mon, 26 Sep 2022 08:31:36 GMT
content-type: text/plain; charset=utf-8
content-length: 200
vary: Cookie

specified SPIAccessToken does not exist: failed to get SPIAccessToken object default/generated-spi-access-token-x6r55: spiaccesstokens.appstudio.redhat.com "generated-spi-access-token-x6r55" not found
```