### PR TITLE
Adapt to the new infra-deployments source code layout

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -21,7 +21,7 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        awk  -i inplace -v n=2 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/kustomization.yaml
+        awk  -i inplace -v n=2 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/base/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest


### PR DESCRIPTION
### What does this PR do?
 - Replace ` quay.io/redhat-appstudio/service-provider-integration-oauth` image tag

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- After migration to kcp infra-deployments source code has a slightly different layout

### How to test this PR?
n/a